### PR TITLE
Use PKG_CHECK_MODULES to detect the libxml2 library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ LT_INIT
 
 AC_PROG_INSTALL
 
+PKG_PROG_PKG_CONFIG
+
 AC_SYS_LARGEFILE
 
 AC_HEADER_STDBOOL
@@ -93,6 +95,7 @@ PKG_CHECK_MODULES(FREETYPE, [freetype2],[
     AC_MSG_ERROR([freetype not found])
 )
 
+PKG_CHECK_MODULES([XML2], [libxml-2.0 >= 2.6.0])
 
 AC_ARG_ENABLE([default-video-format],
 AS_HELP_STRING([--enable-default-video-format=format], [specify a default video format, either NTSC or PAL, to be used if no configuration or input setting is given]),
@@ -127,11 +130,6 @@ AM_CONDITIONAL(HAVE_DVDREAD, $have_dvdread)
 dnl AM_LANGINFO_CODESET
 
 AM_ICONV
-
-ifdef([AM_PATH_XML2],
-    [AM_PATH_XML2(2.6.0, , AC_MSG_ERROR([You must have libxml2 >= 2.6.0 installed]))],
-    [errprint([You must have libxml2 (>= 2.6.0) installed
-])m4_exit(1)AC_MSG_ERROR([You must have libxml2 (>= 2.6.0) installed])])
 
 AC_CHECK_DECLS(O_BINARY, , , [ #include <fcntl.h> ] )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,7 @@ endif
 nodist_bin_SCRIPTS = dvddirdel
 
 AM_CPPFLAGS = -DSYSCONFDIR="\"$(sysconfdir)\"" \
-    @XML_CPPFLAGS@ @MAGICK_CFLAGS@ @FREETYPE_CPPFLAGS@ @FRIBIDI_CFLAGS@ @FONTCONFIG_CFLAGS@
+    @XML2_CFLAGS@ @MAGICK_CFLAGS@ @FREETYPE_CPPFLAGS@ @FRIBIDI_CFLAGS@ @FONTCONFIG_CFLAGS@
 AM_CFLAGS = -Wall
 
 dvdauthor_SOURCES = dvdauthor.c common.h dvdauthor.h da-internal.h \
@@ -16,17 +16,17 @@ dvdauthor_SOURCES = dvdauthor.c common.h dvdauthor.h da-internal.h \
     dvdifo.c dvdvob.c dvdpgc.c \
     dvdcli.c readxml.c readxml.h \
     conffile.c conffile.h compat.c compat.h rgb.h
-dvdauthor_LDADD = $(LIBICONV) $(XML_LIBS)
+dvdauthor_LDADD = $(LIBICONV) $(XML2_LIBS)
 
 dvdunauthor_SOURCES = dvdunauthor.c dvduncompile.c common.h dvduncompile.h compat.c compat.h
-dvdunauthor_LDADD = $(XML_LIBS) $(LIBICONV) -ldvdread
+dvdunauthor_LDADD = $(XML2_LIBS) $(LIBICONV) -ldvdread
 
 spumux_SOURCES = subgen.c subgen.h rgb.h \
     subgen-parse-xml.c readxml.c readxml.h \
     subgen-encode.c subgen-image.c subglobals.h \
     conffile.c conffile.h compat.c compat.h common.h \
     subrender.c subrender.h subreader.c subreader.h subfont.c subfont.h
-spumux_LDADD = $(XML_LIBS) $(MAGICK_LIBS) $(FREETYPE_LIBS) \
+spumux_LDADD = $(XML2_LIBS) $(MAGICK_LIBS) $(FREETYPE_LIBS) \
     $(FRIBIDI_LIBS) $(FONTCONFIG_LIBS) $(LIBICONV) -lm
 
 spuunmux_SOURCES = spuunmux.c rgb.h compat.c compat.h common.h conffile.h conffile.c


### PR DESCRIPTION
This patch uses the PKG_CHECK_MODULES pkg-config macro to detect the libxml2 library.

For Debian bug #949098